### PR TITLE
Implement extra license argument

### DIFF
--- a/dap2rpm/__init__.py
+++ b/dap2rpm/__init__.py
@@ -15,6 +15,8 @@ def main():
                         help='Include all files in the %%files section in SPEC (not recommended)')
     parser.add_argument('-l', '--filelist', action='store_true',
                         help='Output only the list of %%files (used during %%assistant_install)')
+    parser.add_argument('-L', '--license-file', default=None,
+                        help='What file from the doc dir should be used as %%license in %%files')
     parser.add_argument('-s', '--save-dap', default=None, metavar='LOCATION',
                         help='Save the DAP to a given directory (useful especially ' +
                              'when downloading from DAPI)')
@@ -26,7 +28,7 @@ def main():
         # TODO: log error
         sys.exit(1)
 
-    d = dap.DAP.get_dap(args['dap'], args['version'], args['save_dap'])
+    d = dap.DAP.get_dap(args['dap'], args['version'], args['save_dap'], args['license_file'])
 
     if args['filelist']:
         print(d.render_files())

--- a/dap2rpm/files.template
+++ b/dap2rpm/files.template
@@ -1,3 +1,6 @@
+{% if licensefile %}
+%license %{assistant_path}/{{ licensefile }}
+{% endif %}
 {% if doc %}
 %doc %{assistant_path}/{{ doc }}/%{shortname}
 {% endif %}


### PR DESCRIPTION
So now I implemented something for #4.

The usage is as follows:

```
$ dap2rpm -l ../dap-git/git-0.10.0.dap -L LICENSE
%license %{assistant_path}/doc/%{shortname}/LICENSE
%doc %{assistant_path}/doc/%{shortname}
%{assistant_path}/snippets/%{shortname}*
%{assistant_path}/meta/%{shortname}.yaml
```

There might be a problem, that the `%doc` contains the directory where the `%license` file is located. I have no idea yet if that will break the RPM build or is against the rules anyhow, will investigate.

If this is indeed a problem, the output gets messy (needs to be implemented):

```
$ dap2rpm -l ../dap-git/git-0.10.0.dap -L LICENSE
%license %{assistant_path}/doc/%{shortname}/LICENSE
%doc %{assistant_path}/doc/%{shortname}/every
%doc %{assistant_path}/doc/%{shortname}/other
%doc %{assistant_path}/doc/%{shortname}/file
%doc %{assistant_path}/doc/%{shortname}/one
%doc %{assistant_path}/doc/%{shortname}/by
%doc %{assistant_path}/doc/%{shortname}/one_
%{assistant_path}/snippets/%{shortname}*
%{assistant_path}/meta/%{shortname}.yaml
```

So I don't want to go there unless necessary.
